### PR TITLE
Change assumptions for ID length

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -10,7 +10,7 @@ use serde_derive::Deserialize;
 
 #[derive(Debug)]
 struct File {
-    id: u32,
+    id: u64,
     filename: String,
     url: String,
     size: u32,
@@ -25,7 +25,7 @@ impl Display for File {
 
 #[derive(Deserialize, Debug)]
 struct FileResponse {
-    id: u32,
+    id: u64,
     filename: String,
     url: String,
     size: u32,
@@ -37,7 +37,7 @@ struct FileResponse {
 pub struct DownloadCommand {
     /// Canvas course ID
     #[clap(long, short)]
-    course: Option<u32>,
+    course: Option<u64>,
 
     /// Canvas URL to parse
     #[clap(long, short)]
@@ -45,7 +45,7 @@ pub struct DownloadCommand {
 
     /// Canvas file IDs
     #[clap(value_parser, num_args = 1.., value_delimiter = ' ')]
-    files: Option<Vec<u32>>,
+    files: Option<Vec<u64>>,
 
     /// Output directory
     #[clap(long, short)]
@@ -83,11 +83,11 @@ impl DownloadCommand {
 
             let captures = regex.captures(&canvas_assignment_url).unwrap();
             base_url = captures.get(1).unwrap().as_str().to_string();
-            course_id = Some(captures.get(2).unwrap().as_str().parse::<u32>().unwrap());
+            course_id = Some(captures.get(2).unwrap().as_str().parse::<u64>().unwrap());
         }
 
         if let Ok(env_canvas_course_id) = std::env::var("CANVAS_COURSE_ID") {
-            course_id = Some(env_canvas_course_id.parse::<u32>().unwrap())
+            course_id = Some(env_canvas_course_id.parse::<u64>().unwrap())
         }
 
         let base_url = base_url;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub type DateTime = chrono::DateTime<chrono::Utc>;
 #[derive(Debug, Hash, Clone, PartialEq, Eq)]
 pub struct Course {
     pub name: String,
-    pub id: u32,
+    pub id: u64,
     is_favorite: bool,
     css_color: Option<String>,
     created_at: DateTime,
@@ -17,7 +17,7 @@ pub struct Course {
 
 #[derive(Deserialize, Debug)]
 struct CourseResponse {
-    id: u32,
+    id: u64,
     name: String,
     is_favorite: bool,
     created_at: DateTime,
@@ -47,7 +47,7 @@ impl Display for Course {
 
 impl Course {
     pub async fn fetch(
-        course_id: Option<u32>,
+        course_id: Option<u64>,
         base_url: &str,
         client: &Client,
     ) -> Result<Course, anyhow::Error> {
@@ -63,7 +63,7 @@ impl Course {
                 .await?;
             log::info!("Made REST request to get course information");
 
-            let course_colors: HashMap<u32, String> = client
+            let course_colors: HashMap<u64, String> = client
                 .get(format!("{}/api/v1/users/self/colors", base_url))
                 .send()
                 .await?
@@ -72,7 +72,7 @@ impl Course {
                 .custom_colors
                 .into_iter()
                 .filter(|(k, _)| k.starts_with("course_"))
-                .map(|(k, v)| (k.trim_start_matches("course_").parse::<u32>().unwrap(), v))
+                .map(|(k, v)| (k.trim_start_matches("course_").parse::<u64>().unwrap(), v))
                 .collect();
             log::info!("Made REST request to get course colors");
 
@@ -102,7 +102,7 @@ impl Course {
 
             log::info!("Made REST request to get favorite courses");
 
-            let course_colors: HashMap<u32, String> = client
+            let course_colors: HashMap<u64, String> = client
                 .get(format!("{}/api/v1/users/self/colors", base_url))
                 .send()
                 .await?
@@ -111,7 +111,7 @@ impl Course {
                 .custom_colors
                 .into_iter()
                 .filter(|(k, _)| k.starts_with("course_"))
-                .map(|(k, v)| (k.trim_start_matches("course_").parse::<u32>().unwrap(), v))
+                .map(|(k, v)| (k.trim_start_matches("course_").parse::<u64>().unwrap(), v))
                 .collect();
             log::info!("Made REST request to get course colors");
 

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -11,7 +11,7 @@ use serde_derive::Deserialize;
 
 #[derive(Debug)]
 struct Assignment {
-    id: u32,
+    id: u64,
     name: String,
     due_at: Option<DateTime>,
     is_graded: bool,
@@ -25,7 +25,7 @@ impl Display for Assignment {
 
 #[derive(Deserialize, Debug)]
 struct AssignmentResponse {
-    id: u32,
+    id: u64,
     name: String,
     due_at: Option<DateTime>,
     locked_for_user: bool,
@@ -41,7 +41,7 @@ struct UploadBucket {
 
 #[derive(Deserialize, Debug)]
 struct UploadResponse {
-    id: u32,
+    id: u64,
     display_name: Option<String>,
 }
 
@@ -57,11 +57,11 @@ pub struct SubmitCommand {
 
     /// Canvas course ID
     #[clap(long, short)]
-    course: Option<u32>,
+    course: Option<u64>,
 
     /// Canvas assignment ID
     #[clap(long, short)]
-    assignment: Option<u32>,
+    assignment: Option<u64>,
 }
 
 impl SubmitCommand {
@@ -112,18 +112,18 @@ impl SubmitCommand {
 
             let captures = regex.captures(&canvas_assignment_url).unwrap();
             base_url = captures.get(1).unwrap().as_str().to_string();
-            course_id = Some(captures.get(2).unwrap().as_str().parse::<u32>().unwrap());
+            course_id = Some(captures.get(2).unwrap().as_str().parse::<u64>().unwrap());
             if let Some(a_id) = captures.get(3) {
-                assignment_id = Some(a_id.as_str().parse::<u32>().unwrap());
+                assignment_id = Some(a_id.as_str().parse::<u64>().unwrap());
             }
         }
 
         if let Ok(env_canvas_course_id) = std::env::var("CANVAS_COURSE_ID") {
-            course_id = Some(env_canvas_course_id.parse::<u32>().unwrap())
+            course_id = Some(env_canvas_course_id.parse::<u64>().unwrap())
         }
 
         if let Ok(env_canvas_assignment_id) = std::env::var("CANVAS_ASSIGNMENT_ID") {
-            assignment_id = Some(env_canvas_assignment_id.parse::<u32>().unwrap())
+            assignment_id = Some(env_canvas_assignment_id.parse::<u64>().unwrap())
         }
 
         let base_url = base_url;


### PR DESCRIPTION
It is incorrect to believe that the class ID will always be <u32. One of my class IDs is unusually large, reaching up to around 2^52. I presume this same assumption to be incorrect for the assignment and file IDs as well.

Tested download, did not test submission. Will test submission before mid-April, if desired before merging.